### PR TITLE
fix: gateway API_BASE_URL 포트 제거 (내부 포트 80 통일)

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,1 +1,1 @@
-API_BASE_URL=http://backend-api-server-gateway:3000
+API_BASE_URL=http://backend-api-server-gateway


### PR DESCRIPTION
## Summary

- `.env.prod` `API_BASE_URL`에서 포트 제거 (`gateway:3000` → `gateway`)
- gateway 컨테이너가 포트 80으로 통일되면서 발생한 504 에러 수정

## 원인

iac-terraform에서 `SERVER_PORT: 80`으로 배포 후 gateway가 포트 80에서 기동되었으나,
`API_BASE_URL`이 여전히 `:3000`을 바라보고 있어 연결 실패 → axios hang → nginx 504 발생.

## Test plan

- [ ] `payment.montyoh.dev` 접속 후 결제 내역 정상 조회 확인
- [ ] 504 에러 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)