### PR TITLE
ci: 빌드 job을 arm64 러너로 전환, QEMU 제거

### DIFF
--- a/.github/workflows/manual-redeploy.yml
+++ b/.github/workflows/manual-redeploy.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   manual_redeploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Check out repository
@@ -36,9 +36,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ env.DOCKER_REGISTRY_ACCESS_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/pull-request-master.yml
+++ b/.github/workflows/pull-request-master.yml
@@ -32,14 +32,11 @@ jobs:
   pull_request_master:
     needs: detect_changes
     if: needs.detect_changes.outputs.any_changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -32,7 +32,7 @@ jobs:
   push_master:
     needs: detect_changes
     if: needs.detect_changes.outputs.any_changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Check out repository
@@ -63,9 +63,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ env.DOCKER_REGISTRY_ACCESS_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
- ubuntu-24.04-arm 네이티브 빌드로 QEMU 에뮬레이션 크래시 회피
- detect_changes는 ubuntu-latest 유지